### PR TITLE
Fix URL typo in README

### DIFF
--- a/README
+++ b/README
@@ -40,4 +40,4 @@ Crossref provided funding to support the development of the version 1.0 of this 
 Contact/Support
 ---------------
 Documentation, bug listings, and updates can be found on this plugin's homepage
-at <https://github.com/pkp/crossrefReferenceLinkign>.
+at <https://github.com/pkp/crossrefReferenceLinking>.


### PR DESCRIPTION
I'm not sure which branch to base this PR against -- let me know if it needs to go against `stable-*`.