### PR TITLE
Update displayDOI.tpl

### DIFF
--- a/templates/displayDOI.tpl
+++ b/templates/displayDOI.tpl
@@ -8,4 +8,4 @@
  * Display reference DOI on the article metadata (backend) and article view page (frontend)
  *}
  
-DOI: <a href="{$crossrefFullUrl|escape}">{$crossrefFullUrl|escape}</a>
+<a href="{$crossrefFullUrl|escape}">{$crossrefFullUrl|escape}</a>


### PR DESCRIPTION
"DOI: " should not be included according to Crossref's display guidelines: https://www.crossref.org/display-guidelines/#how-to-display-a-crossref-doia-id00472-href00472a