### PR TITLE
Fix duplicate DOI display in citation references (case-insensitive match)

### DIFF
--- a/CrossrefReferenceLinkingPlugin.inc.php
+++ b/CrossrefReferenceLinkingPlugin.inc.php
@@ -424,11 +424,14 @@ class CrossrefReferenceLinkingPlugin extends GenericPlugin {
         $doi = $citation->getData($this->getCitationDoiSettingName());
 
         if ($doi) {
-            $doiUrl = 'https://doi.org/' . $doi;
             $rawCitation = $citation->getRawCitation();
+            $doiUrl = 'https://doi.org/' . $doi;
+
+            // Normalize to lowercase for comparison
+            $rawCitationNormalized = strtolower($rawCitation);
 
             // If the raw citation already contains a DOI URL, remove it
-            if (strpos($rawCitation, $doiUrl) !== false) {
+            if (strpos($rawCitationNormalized, strtolower($doiUrl)) !== false) {
                 // Remove exactly matching linked DOI or plain text DOI URL
                 $rawCitation = preg_replace(
                     '#<a[^>]+href=["\']' . preg_quote($doiUrl, '#') . '["\'][^>]*>[^<]*</a>#i',


### PR DESCRIPTION
This PR improves the handling of DOI links in citation references.

Automatically removes manually entered DOI links or plain text DOI URLs from citations before displaying the system-generated DOI link.

- Handles matching in a case-insensitive way to align with Crossref standards (DOIs are case-insensitive).
- Ensures that other links in citations (e.g., PubMed or publisher links) are left untouched.
- Preserves the original DOI casing for display to maintain professional formatting.

This fix avoids confusion from duplicate DOIs appearing in the reference list, while keeping references clean and consistent.

Fixes: pkp/crossrefReferenceLinking#16